### PR TITLE
fix(readme): missing attribute for loading-src

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Make sure you use `ng-src` as your image src attribute.
 `<img ng-src="{{'path/to/img.jpg'}}" fallback-src="{{'path/to/fallback.jpg'}}" />`
 
 - Loading placeholder, show a loading placeholder until image loads<br />
-`<img ng-src="{{'path/to/img.jpg'}}" />`
+`<img ng-src="{{'path/to/img.jpg'}}" loading-src />`
 
 - Custom Loading placeholder, show a custom image loading placeholder until image loads<br />
 `<img ng-src="{{'path/to/img.jpg'}}" loading-src="{{'path/to/loading.jpg'}}" />`


### PR DESCRIPTION
Missing the loading-src attribute in the example HTML to show usage of loading placeholder